### PR TITLE
Tweaks to slot rendering, add ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 8
   },
   "extends": "eslint:recommended",
   "rules": {
@@ -24,7 +24,7 @@
 
     "array-bracket-spacing": ["warn", "never"],
     "block-spacing": ["warn", "always"],
-    "brace-style": ["warn", "allman"],
+    "brace-style": ["warn", "1tbs"],
     "camelcase": ["warn", {"properties": "always"}],
     "comma-spacing": [
       "warn",
@@ -34,7 +34,7 @@
       }
     ],
     "comma-style": ["warn", "last"],
-    "indent": ["warn", "tab", {"SwitchCase": 1}],
+    "indent": ["warn", 2, {"SwitchCase": 1}],
     "new-cap": [
       "warn",
       {
@@ -75,6 +75,6 @@
   },
   "env": {
     "browser": true,
-    "jquery": true
+    "es6": true
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,77 @@
+{
+  "extends": "eslint:recommended",
+  "rules": {
+    "no-console": ["off"],
+    "curly": ["error", "all"],
+    "default-case": ["error"],
+    "no-eval": ["error"],
+    "no-multi-spaces": [
+      "warn",
+      {
+        "ignoreEOLComments": true,
+        "exceptions": {
+          "Property": true,
+          "VariableDeclarator": true,
+          "ImportDeclaration": true
+        }
+      }
+    ],
+    "no-shadow": ["error"],
+    "no-undefined": ["error"],
+
+    "array-bracket-spacing": ["warn", "never"],
+    "block-spacing": ["warn", "always"],
+    "brace-style": ["warn", "allman"],
+    "camelcase": ["warn", {"properties": "always"}],
+    "comma-spacing": [
+      "warn",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "comma-style": ["warn", "last"],
+    "indent": ["warn", "tab", {"SwitchCase": 1}],
+    "new-cap": [
+      "warn",
+      {
+        "newIsCap": true,
+        "capIsNew": true,
+        "properties": false
+      }
+    ],
+    "no-mixed-spaces-and-tabs": ["warn", "smart-tabs"],
+    "no-multiple-empty-lines": ["warn"],
+    "no-nested-ternary": ["warn"],
+    "no-spaced-func": ["warn"],
+    "no-trailing-spaces": ["warn"],
+    "semi": ["warn", "always"],
+    "space-in-parens": ["warn", "never"],
+    "space-infix-ops": ["warn"],
+    "spaced-comment": [
+      "warn",
+      "always",
+      {
+        "block":
+        {
+          "exceptions": ["*"]
+        }
+      }
+    ],
+    "require-jsdoc": [
+      "error",
+      {
+        require: {
+          "FunctionDeclaration": true,
+          "MethodDefinition": true,
+          "ClassDeclaration": false
+        }
+      }
+    ],
+    "valid-jsdoc": ["error"]
+  },
+  "env": {
+    "browser": true,
+    "jquery": true
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "extends": "eslint:recommended",
   "rules": {
     "no-console": ["off"],

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ jobs:
         - npm install -g eslint
       script: eslint pyfahviewer/static/*.js
 
-deploy:
-  provider: releases
-  api_key:
-    secure: KnwDncons7xVHkNv+O/PkKvaHxxM0YCnQBaLFARqrNfP4Zg304YOQM+PjZwNKBdPJU1qWUcdlTaTFTGTuHJPuPqALLRjPt9mhXCq5azVqwqeCz20kHBmPWnKsO3zPp60BX7bWjAuEyyfmy/yAci/MIBaILGhpozqr9m431jAf6AKFBMH010E96AV3YNAuFoTUcEvCWF764iDebAh+ql0xhIhpAk3vYZSiHZ92EkRedujUpdtwOmdqfezyGUs8sAcWqeXmeW3U65RuoWpnVbLDZONJhqRMQd+VlNwpehQYzsT37ikCidiMRA8p4Du9mwzaQ21tTUkyjd8MedbjUqm1p8sDPuKEgAgsmgbLKT9B4EID7ckfkouEKsxYsi9HavLaGAfBMKIHbpNxxopxl9bK+kDHLMNLWP/ne/JWwuiIqoz6rhKTQewXFMjp+Nc9onW0b7EgnwScqjEDFfIcjmbtQjEatR0FftqMaA49t04QC18/M11H8h1q+wF9332OFogEXZM7dld8Tbf/3L6sTow7YIetKO/prTHggL+E4QtoYsl3YuZ2lOiGbueczhe5BGQoIw+t7NJOLsDVA57tIkqrCYzWTcI5Xz2KLZdG9u7eR9Wl/upY7pudFhoyWFPC39MwoZDhDWnHGv5L1iUllh7g6iKUbtS5KfFTMaS+ueO8uM=
-  on:
-    tags: true
+    - name: "Deploy"
+      if: tag IS present
+      deploy:
+        provider: releases
+        api_key:
+          secure: KnwDncons7xVHkNv+O/PkKvaHxxM0YCnQBaLFARqrNfP4Zg304YOQM+PjZwNKBdPJU1qWUcdlTaTFTGTuHJPuPqALLRjPt9mhXCq5azVqwqeCz20kHBmPWnKsO3zPp60BX7bWjAuEyyfmy/yAci/MIBaILGhpozqr9m431jAf6AKFBMH010E96AV3YNAuFoTUcEvCWF764iDebAh+ql0xhIhpAk3vYZSiHZ92EkRedujUpdtwOmdqfezyGUs8sAcWqeXmeW3U65RuoWpnVbLDZONJhqRMQd+VlNwpehQYzsT37ikCidiMRA8p4Du9mwzaQ21tTUkyjd8MedbjUqm1p8sDPuKEgAgsmgbLKT9B4EID7ckfkouEKsxYsi9HavLaGAfBMKIHbpNxxopxl9bK+kDHLMNLWP/ne/JWwuiIqoz6rhKTQewXFMjp+Nc9onW0b7EgnwScqjEDFfIcjmbtQjEatR0FftqMaA49t04QC18/M11H8h1q+wF9332OFogEXZM7dld8Tbf/3L6sTow7YIetKO/prTHggL+E4QtoYsl3YuZ2lOiGbueczhe5BGQoIw+t7NJOLsDVA57tIkqrCYzWTcI5Xz2KLZdG9u7eR9Wl/upY7pudFhoyWFPC39MwoZDhDWnHGv5L1iUllh7g6iKUbtS5KfFTMaS+ueO8uM=
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,30 @@
-language: python
-python:
-  - '3.5'
-  - '3.6'
-  - '3.7'
-  - '3.8'
+os: linux
 
-env:
-  - SKIP_INTERPRETER=true
+jobs:
+  include:
+    - language: python
+      name: "Lint Python"
+      python:
+        - '3.5'
+        - '3.6'
+        - '3.7'
+        - '3.8'
+      env:
+        - SKIP_INTERPRETER=true
+      before_install:
+        - git clone https://github.com/TravisToolbox/pycodestyle-travis.git
+      install:
+        - "pip install -r requirements.txt"
+        - "./pycodestyle-travis/install.sh"
+      script:
+        - "./pycodestyle-travis/scan.sh"
 
-before_install:
-      - git clone https://github.com/TravisToolbox/pycodestyle-travis.git
-install:
-  - "pip install -r requirements.txt"
-  - "./pycodestyle-travis/install.sh"
-
-script:
-  - "./pycodestyle-travis/scan.sh"
+    - language: node_js
+      name: "Lint JavaScript"
+      node_js: 13
+      install:
+        - npm install -g eslint
+      script: eslint pyfahviewer/static/*.js
 
 deploy:
   provider: releases

--- a/pyfahviewer/static/main.js
+++ b/pyfahviewer/static/main.js
@@ -22,7 +22,10 @@
     window.setInterval(loadData, 10000);
   });
 
-  // Window resize event handler.
+  /**
+   * Window resize event handler.
+   * @return {undefined}
+   */
   function onResize() {
     // Don't resize slots while fetching
     if (!fetching) {
@@ -44,11 +47,14 @@
       let slotsWillExceedView = doSlotsExceedViewableArea(slotsClone);
       resizeSlots(slotsContainer, slotsWillExceedView);
 
-      slotsClone.remove()
+      slotsClone.remove();
     }
   }
 
-  // Fetches data from the API.
+  /**
+   * Fetches data from the API.
+   * @return {undefined}
+   */
   async function loadData() {
     if (fetching) {
       console.log("Did not fetch because a fetch is already in progress.");
@@ -69,7 +75,10 @@
     fetching = false;
   }
 
-  // Loads and renders the leaderboard data.
+  /**
+   * Loads and renders the leaderboard data.
+   * @returns {undefined}
+   */
   async function refreshTeam() {
     let response = null;
     try {
@@ -86,7 +95,10 @@
     renderTeamStats(teamData);
   }
 
-  // Loads and renders the slot data.
+  /**
+   * Loads and renders the slot data.
+   * @returns {undefined}
+   */
   async function refreshSlots() {
     let response = null;
     try {
@@ -103,7 +115,11 @@
     renderSlotStats(slotData);
   }
 
-  // Renders loaded leaderboard data.
+  /**
+   * Renders loaded leaderboard data.
+   * @param {Object} teamData Response from team data API.
+   * @returns {undefined}
+   */
   function renderTeamStats(teamData) {
     if (teamData === null) {
       return;
@@ -122,7 +138,7 @@
     document.getElementById("team-rank").innerHTML = "Rank: " + Number(teamData.rank).toLocaleString();
     document.getElementById("leader-header").classList.remove("hidden");
 
-    for (i = 0; i < 15; i++) {
+    for (let i = 0; i < 15; i++) {
       let donor = teamData.donors[i];
       table.querySelector("tbody").appendChild(createElementFromHtml(
         "<tr><td class=\"overflow-el\">" +
@@ -137,7 +153,11 @@
     leaderContainer.appendChild(table);
   }
 
-  // Renders loaded slot data.
+  /**
+   * Renders loaded slot data.
+   * @param {Object} slotData Response from slot data API.
+   * @returns {undefined}
+   */
   function renderSlotStats(slotData) {
     if (slotData === null) {
       return;
@@ -178,7 +198,11 @@
     slotsContainer.style.visibility = "visible";
   }
 
-  // Creates a new view for a particular slot.
+  /**
+   * Creates a new view for a particular slot.
+   * @param {Object} slotData Response from the slot data API.
+   * @returns {Object} An HTML element representing a single slot.
+   */
   function generateIndividualSlot(slotData) {
     let slotNode = slotTemplate.cloneNode(true);
 
@@ -197,8 +221,7 @@
     let state = slotData.status.toLowerCase();
     if (state === "paused" || state === "stopping") {
       slotNode.querySelector(".progress-inner").classList.add("paused");
-    }
-    else if (state === "ready" || state === "uploading" || state === "downloading") {
+    } else if (state === "ready" || state === "uploading" || state === "downloading") {
       slotNode.querySelector(".progress-inner").classList.add("waiting");
       percentDone = 100;
       percentCompleteText = "Retry in " + slotData.queue.nextattempt;
@@ -228,7 +251,11 @@
     return slotNode;
   }
 
-  // Determines whether slots view would exceed the viewable bounds of the slot section.
+  /**
+   * Determines whether slots view would exceed the viewable bounds of the slot section.
+   * @param {Object} slotsInnerContainer The HTML element directly containing all of the individual slots.
+   * @returns {bool} True if the slots would exceed the viewable area if rendered.
+   */
   function doSlotsExceedViewableArea(slotsInnerContainer) {
     if (slotsInnerContainer === null) {
       return false;
@@ -241,8 +268,13 @@
     return slotsHeight > containerHeight;
   }
 
-  // Switches slots to a minimal or expanded view, depending on the requireSmall parameter.
-  function resizeSlots(slotsInnerContainer, requireSmall=false) {
+  /**
+   * Switches slots to a minimal or expanded view, depending on the requireSmall parameter.
+   * @param {Object} slotsInnerContainer The HTML element directly containing all of the individual slots.
+   * @param {bool} requireSmall Whether the minimized view should be applied or not.
+   * @returns {undefined}
+   */
+  function resizeSlots(slotsInnerContainer, requireSmall = false) {
     // If passed a non-existent container (window resized while still loading), do nothing.
     if (slotsInnerContainer === null) {
       return;
@@ -255,21 +287,27 @@
     }
   }
 
-  /*
+  /**
    * Formats the title of the slot.
    * CPU slots: "CPU (# of cores)"
    * GPU slots: GPU model name
+   * @param {Object} slot The slot for which to format the name.
+   * @returns {string} The formatted slot title.
    */
   function formatSlotName(slot) {
     if (slot.type === "cpu") {
       return slot.name + " (" + slot.cores + ")";
     }
 
-    let re = /^[^\[]*\[(.*)\]/;
+    let re = /^[^[]*\[(.*)\]/;
     return slot.name.match(re)[1];
   }
 
-  // Generates an Element from an HTML string. Returns the first element in the string.
+  /**
+   * Generates an Element from an HTML string. Returns the first element in the string.
+   * @param {string} html The HTML to generate an element from.
+   * @returns {Object} The created HTML element.
+   */
   function createElementFromHtml(html) {
     let template = document.createElement('template');
     html = html.trim();

--- a/pyfahviewer/static/style.css
+++ b/pyfahviewer/static/style.css
@@ -135,6 +135,10 @@ th, td {
   margin: 7px;
 }
 
+.slot-bounds.too-many-slots .slot {
+  flex-basis: 200px;
+}
+
 .slot .text-content {
   margin: 10px;
 }
@@ -149,6 +153,7 @@ th, td {
 .slot .progress-bar .slot-progress {
   display: inline-block;
   padding: 3px 10px;
+  white-space: nowrap;
 }
 
 .slot .progress-bar .progress-inner {


### PR DESCRIPTION
 * Fixes #10 - Progress bars can no longer overflow onto a second line.
 * Reduces minimum width of slots when in minimal display mode to limit wasted space.
 * Adds ESLint to validata JavaScript.
 * Fixed an issue where resizing the window could cause slots to inappropriately expand until another resize or the next successful slot API refresh.
 * Changed progress bar on slots in ready state to display time remaining to next retry.